### PR TITLE
Add update/set method to Customer

### DIFF
--- a/src/Api/Customers.php
+++ b/src/Api/Customers.php
@@ -46,4 +46,14 @@ class Customers extends AbstractApi
             'customer' => ['get' => ['filter' => $params, 'dataset' => ['gen_info' => [], 'stat' => []]]]
         ]);
     }
+
+    /**
+     * @param $params
+     * @return mixed
+     * @throws \Http\Client\Exception
+     */
+    public function update($params)
+    {
+        return $this->post(['customer' => ['set' => [$params]]]);
+    }
 }


### PR DESCRIPTION
Added missing update/set method to the Customer API.

https://docs.plesk.com/en-US/onyx/api-rpc/about-xml-api/reference/managing-customer-accounts/setting-customer-account-properties.28792/#o34620